### PR TITLE
Specify encoding to avoid UnicodeEncodeError

### DIFF
--- a/civitai-image.py
+++ b/civitai-image.py
@@ -42,7 +42,7 @@ for image in tqdm(filtered_images, desc="Saving images and metadata", unit="imag
     # Save meta.prompt as a text file
     meta_prompt = image_meta['prompt']
     meta_filename = f"{image_id}.txt"
-    with open(meta_filename, "w") as meta_file:
+    with open(meta_filename, "w", encoding='utf-8') as meta_file:
         meta_file.write(meta_prompt)
 
     total_saved += 1


### PR DESCRIPTION
While running the script I get UnicodeEncodeError.

```
  File "C:\Users\Szymon\civitai-scraper\civitai-image.py", line 46, in <module>
    meta_file.write(meta_prompt)
  File "C:\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\uff0c' in position 222: character maps to <undefined>
```

This adds utf-8 encoding to resolve the issue.